### PR TITLE
피드 API 수정, 토몽 다크 모드 추가 외 2건

### DIFF
--- a/src/app/api/post/feeds/route.js
+++ b/src/app/api/post/feeds/route.js
@@ -92,6 +92,7 @@ export async function GET(request, { params }) {
         "imageUrls",
         "tomong",
         "tomongSelected",
+        "isPrivate",
       ],
     });
 

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -6,6 +6,7 @@ import Providers from "@/components/Providers";
 import { metadataMaker } from "@/utils/metadata";
 import { themeScript } from "@/utils/themeScript";
 import { CustomScrollbar } from "@/components/Controls";
+import ThemeHandler from "@/components/theme/ThemeHandler";
 
 export const metadata = metadataMaker();
 
@@ -16,8 +17,10 @@ export default function RootLayout({ children }) {
         <script dangerouslySetInnerHTML={themeScript()} />
       </head>
       <body>
-        <Providers>{children}</Providers>
-        <CustomScrollbar />
+        <ThemeHandler>
+          <Providers>{children}</Providers>
+          <CustomScrollbar />
+        </ThemeHandler>
       </body>
     </html>
   );

--- a/src/app/tomong/Tomong.module.css
+++ b/src/app/tomong/Tomong.module.css
@@ -12,7 +12,7 @@
 .main {
   width: 80vw;
   height: 80vh;
-  background-color: #fff;
+  background-color: var(--background-white);
   border-radius: 1.5rem;
   display: grid;
   grid-template-rows: auto 1fr auto;
@@ -134,6 +134,7 @@
 
 ul.post-tag {
   display: flex;
+  flex-wrap: wrap;
   margin-top: 1.6rem;
 }
 
@@ -225,5 +226,39 @@ ul.post-tag li {
 @media (max-width: 768px) {
   .dreams-list li {
     width: 90%;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .container h1 img {
+    filter: var(--filter-EEF0DE);
+  }
+
+  .container p,
+  .container span,
+  .container h2,
+  .container h3 {
+    color: var(--black-font-color);
+  }
+
+  .container p {
+    position: relative;
+    z-index: 10;
+  }
+
+  .dreams-list li {
+    background-color: var(--comment-input-color);
+  }
+
+  .tomong-results-chevrons {
+    filter: var(--filter-EEF0DE);
+  }
+
+  .carousel-indicator {
+    background-color: #666;
+  }
+
+  .carousel-indicator.active {
+    background-color: #ddd;
   }
 }

--- a/src/app/tomong/page.js
+++ b/src/app/tomong/page.js
@@ -479,9 +479,11 @@ export default function Tomong() {
 
   return (
     <div className={styles["container"]}>
-      <Link href="/">
-        <img src="/images/logo-full.svg" alt="DREAMER" width={240} />
-      </Link>
+      <h1>
+        <Link href="/">
+          <img src="/images/logo-full.svg" alt="DREAMER" width={240} />
+        </Link>
+      </h1>
       <main className={styles["main"]}>
         {process === 0 && <TomongIntro setProcess={setProcess} />}
         {process === 1 && (

--- a/src/components/modal/PostModal.module.css
+++ b/src/components/modal/PostModal.module.css
@@ -332,22 +332,24 @@ input[type="checkbox"]:checked + label.checkbox::before {
 
 @media (max-width: 720px) {
   .post-modal {
-    padding: 2rem 0 2rem 2rem;
+    padding: 2rem 2rem 2rem 2rem;
     flex-direction: column;
     min-width: 34rem;
+    overflow-y: scroll;
   }
 
   .post-section {
-    padding-right: 2rem;
-    padding-bottom: 8rem;
+    padding-right: 0;
+    margin-right: 0;
+    padding-bottom: 3rem;
     margin-bottom: 1rem;
-    height: 50%;
     background: url(/images/dash.svg) repeat-x bottom;
     background-size: 12px 2px;
   }
   .post-text {
     min-width: 30rem;
-    height: 80%;
+    height: fit-content;
+    max-height: max-content;
   }
 
   .button-list {
@@ -367,6 +369,11 @@ input[type="checkbox"]:checked + label.checkbox::before {
 
   .comment-form {
     max-height: 5rem;
+    margin: 1.5rem 0 4.5rem;
+  }
+
+  .comment-articles-section {
+    overflow-y: auto;
   }
   .comment-input {
     height: 5rem;

--- a/src/components/modal/PostModal.module.css
+++ b/src/components/modal/PostModal.module.css
@@ -373,7 +373,9 @@ input[type="checkbox"]:checked + label.checkbox::before {
   }
 
   .comment-articles-section {
-    overflow-y: auto;
+    overflow-y: inherit;
+    max-height: fit-content;
+    padding-top: 1.6rem;
   }
   .comment-input {
     height: 5rem;

--- a/src/components/post/PostContent.jsx
+++ b/src/components/post/PostContent.jsx
@@ -129,7 +129,6 @@ export default function PostContent({
 
   const togglePostPrivacy = async (postId, postIsPrivate) => {
     setIsOpen(false);
-    console.log(postData);
 
     try {
       const response = await fetchWithAuth(`/api/post/private/${postId}`, {
@@ -144,8 +143,6 @@ export default function PostContent({
 
       const responseData = await response.json();
       if (response.ok && responseData.success) {
-        console.log("새로운 비공개 상태:", newPrivacyStatus);
-        console.log(responseData.isPrivate);
         return responseData.isPrivate;
       } else {
         alert(`오류: ${responseData.error}`);

--- a/src/components/theme/ThemeHandler.jsx
+++ b/src/components/theme/ThemeHandler.jsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function ThemeHandler({ children }) {
+  useEffect(() => {
+    // 미디어 쿼리 매칭 상태를 감지하는 함수
+    const handleThemeChange = (e) => {
+      const userTheme = localStorage.getItem("userTheme");
+      const html = document.querySelector("html");
+
+      if (userTheme === "device") {
+        html.dataset.theme = e.matches ? "dark" : "light";
+      }
+    };
+
+    // 미디어 쿼리 매칭 객체 생성
+    const darkModeMediaQuery = window.matchMedia(
+      "(prefers-color-scheme: dark)"
+    );
+
+    // 초기 테마 설정
+    handleThemeChange(darkModeMediaQuery);
+
+    // 시스템 테마 변경 이벤트 리스너 등록
+    darkModeMediaQuery.addEventListener("change", handleThemeChange);
+
+    // 컴포넌트 언마운트 시 이벤트 리스너 제거
+    return () => {
+      darkModeMediaQuery.removeEventListener("change", handleThemeChange);
+    };
+  }, []); // deviceTheme 의존성 제거
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
1. 피드 API에 isPrivate이 반환되지 않는 문제를 수정했습니다.
2. PostModal이 뷰포트 너비 720px 미만일 때 스크롤 영역을 일원화했습니다.
3. 테마 핸들러 컴포넌트를 추가하여 theme이 device일 때 디바이스에서 라이트 모드와 다크 모드를 전환하는 것이 즉각 반영되도록 수정했습니다.
4. 토몽 페이지의 다크 모드 스타일을 추가했습니다.