### PR TITLE
반응형 레이아웃 개선

### DIFF
--- a/public/images/loading-spinner.svg
+++ b/public/images/loading-spinner.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#808080;stop-opacity:0.1" />
+      <stop offset="50%" style="stop-color:#808080;stop-opacity:0.8" />
+      <stop offset="100%" style="stop-color:#808080" />
+    </linearGradient>
+  </defs>
+  <circle 
+    cx="50" 
+    cy="50" 
+    r="40" 
+    stroke="url(#gradient)"
+    stroke-width="8"
+    fill="none"
+    stroke-linecap="round">
+    <animateTransform
+      attributeName="transform"
+      type="rotate"
+      from="0 50 50"
+      to="360 50 50"
+      dur="1s"
+      repeatCount="indefinite" />
+  </circle>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -178,14 +178,24 @@
 html {
   font-size: 62.5%;
   font-family: var(--font-family);
-  /* overflow: hidden; */
-  scrollbar-width: none;
   height: 100%;
   overflow-y: auto;
 }
 
 html::-webkit-scrollbar {
-  display: none;
+  width: 3.2rem;
+}
+
+html::-webkit-scrollbar-thumb {
+  background: var(--scroll-bar-color);
+  height: 18.3rem;
+  border: 1.2rem solid var(--background-color);
+  border-radius: 2.6rem;
+}
+
+html::-webkit-scrollbar-track {
+  background-color: var(--background-color);
+  border-radius: 1.3rem;
 }
 
 html,
@@ -193,7 +203,6 @@ body {
   max-width: 100vw;
   overflow-x: hidden;
   background-color: var(--background-color);
-  overscroll-behavior: none;
 }
 
 body {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -217,15 +217,14 @@ body {
 }
 
 div.root-container:has(header):has(main):has(footer) {
-  display: flex;
-  justify-content: space-evenly;
-  flex-wrap: nowrap;
-  width: 100vw;
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr auto;
   height: auto;
   background-color: var(--background-color);
   column-gap: 6.4rem;
   padding-left: calc(32rem);
-  padding-right: 6.4rem;
+  padding-right: 8.4rem;
 }
 
 div.root-container {
@@ -273,23 +272,23 @@ div.root-container:has(header):has(main):has(footer) main {
 @media (max-width: 1152px) {
   div.root-container:has(header):has(main):has(footer) {
     padding-left: 10.4rem;
-    padding-right: 0;
+    padding-right: calc(6.4rem + (100vw - 969px) * 0.26087 / 16);
   }
 }
 
 @media (max-width: 969px) {
   div.root-container:has(header):has(main):has(footer) main {
-    padding: 16.6rem 0 16.6rem 0;
+    padding: 16.6rem 4rem 16.6rem 4rem;
   }
-}
 
-@media (max-width: 969px) {
   div.root-container:has(header):has(main):has(footer) {
     flex-direction: column;
     width: 100%;
     min-height: 100dvh;
     display: grid;
+    grid-template-columns: 1fr;
     grid-template-rows: 1fr auto;
+    padding-right: 0;
   }
 
   body:has(header):has(main):has(footer) main {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -182,18 +182,22 @@ html {
   overflow-y: auto;
 }
 
-html::-webkit-scrollbar {
+html::-webkit-scrollbar,
+body::-webkit-scrollbar {
   width: 3.2rem;
 }
 
-html::-webkit-scrollbar-thumb {
+html::-webkit-scrollbar-thumb,
+body::-webkit-scrollbar-thumb {
   background: var(--scroll-bar-color);
   height: 18.3rem;
   border: 1.2rem solid var(--background-color);
   border-radius: 2.6rem;
+  z-index: 1000;
 }
 
-html::-webkit-scrollbar-track {
+html::-webkit-scrollbar-track,
+body::-webkit-scrollbar-track {
   background-color: var(--background-color);
   border-radius: 1.3rem;
 }
@@ -212,7 +216,7 @@ body {
   letter-spacing: 0.03em;
 }
 
-body:has(header):has(main):has(footer) {
+div.root-container:has(header):has(main):has(footer) {
   display: flex;
   justify-content: space-evenly;
   flex-wrap: nowrap;
@@ -224,11 +228,16 @@ body:has(header):has(main):has(footer) {
   padding-right: 6.4rem;
 }
 
+div.root-container {
+  width: 100%;
+  height: 100%;
+}
+
 main {
   padding: 8rem;
 }
 
-body:has(header):has(main):has(footer) main {
+div.root-container:has(header):has(main):has(footer) main {
   padding: 16.6rem 0 16.6rem 6.4rem;
 }
 
@@ -262,21 +271,22 @@ body:has(header):has(main):has(footer) main {
 }
 
 @media (max-width: 1152px) {
-  body:has(header):has(main):has(footer) {
+  div.root-container:has(header):has(main):has(footer) {
     padding-left: 10.4rem;
+    padding-right: 0;
   }
 }
 
 @media (max-width: 969px) {
-  body:has(header):has(main):has(footer) main {
+  div.root-container:has(header):has(main):has(footer) main {
     padding: 16.6rem 0 16.6rem 0;
   }
 }
 
 @media (max-width: 969px) {
-  body:has(header):has(main):has(footer) {
+  div.root-container:has(header):has(main):has(footer) {
     flex-direction: column;
-    width: max-content;
+    width: 100%;
     min-height: 100dvh;
     display: grid;
     grid-template-rows: 1fr auto;
@@ -293,12 +303,56 @@ body:has(header):has(main):has(footer) main {
 }
 
 @media (max-width: 720px) {
-  body:has(header):has(main):has(footer) {
-    padding-left: 6.4rem;
-    padding-right: 6.4rem;
+  html:has(header):has(main):has(footer) {
+    width: 100vw;
+    height: 100dvh;
+    /* overflow-y: scroll; */
+    overflow-y: hidden;
   }
 
-  html body:has(header):has(main):has(footer) main {
+  body:has(header):has(main):has(footer) {
+    width: 100vw;
+    height: calc(100dvh - 6rem);
+    padding-left: 0;
+    padding-right: 0;
+
+    /* height: 100%;
+    overflow-y: scroll; */
+  }
+
+  div.root-container {
+    width: inherit;
+    height: calc(100dvh - 6rem);
+    padding-left: 6.4rem;
+    padding-right: 6.4rem;
+    overflow-y: scroll;
+  }
+
+  div.root-container:has(header):has(main):has(footer) {
+    width: 100vw;
+    padding-left: 3.2rem;
+    padding-right: 0;
+  }
+
+  div.root-container::-webkit-scrollbar {
+    width: 3.2rem;
+  }
+
+  div.root-container::-webkit-scrollbar-thumb {
+    background: var(--scroll-bar-color);
+    height: 18.3rem;
+    border: 1.2rem solid var(--background-color);
+    border-radius: 2.6rem;
+    z-index: 1000;
+  }
+
+  div.root-container::-webkit-scrollbar-track {
+    background-color: var(--background-color);
+    border-radius: 1.3rem;
+  }
+
+  div.root-container:has(header):has(main):has(footer) main {
+    width: 100%;
     padding: 3rem 0 3rem 0;
   }
 

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -5,7 +5,6 @@ import "../../public/fonts/NanumBarunPenB/NanumBarunPenB.css";
 import Providers from "@/components/Providers";
 import { metadataMaker } from "@/utils/metadata";
 import { themeScript } from "@/utils/themeScript";
-import { CustomScrollbar } from "@/components/Controls";
 import ThemeHandler from "@/components/theme/ThemeHandler";
 
 export const metadata = metadataMaker();
@@ -19,7 +18,6 @@ export default function RootLayout({ children }) {
       <body>
         <ThemeHandler>
           <Providers>{children}</Providers>
-          <CustomScrollbar />
         </ThemeHandler>
       </body>
     </html>

--- a/src/app/privacy/page.module.css
+++ b/src/app/privacy/page.module.css
@@ -1,6 +1,5 @@
 .main {
-  padding: 10rem 10rem;
-  color: var(--black-font-color); 
+  color: var(--black-font-color);
 }
 
 .main h2 {

--- a/src/components/Loading.jsx
+++ b/src/components/Loading.jsx
@@ -11,11 +11,11 @@ export default function Loading({ type, className }) {
     );
   } else if (type === "full") {
     return (
-      <div id="loading-wrapper" className={styles["loading-container"]}>
+      <main id="loading-wrapper" className={styles["loading-container"]}>
         <div className={styles.loading}>
           <div></div>
         </div>
-      </div>
+      </main>
     );
   } else if (type === "miniCircle") {
     return (

--- a/src/components/Loading.module.css
+++ b/src/components/Loading.module.css
@@ -15,12 +15,12 @@
 
 @keyframes loadingCircle {
   0% {
-    background-image: url(/images/loading.svg);
+    background-image: url(/images/loading-spinner.svg);
     transform: rotateZ(0deg);
   }
 
   100% {
-    background-image: url(/images/loading.svg);
+    background-image: url(/images/loading-spinner.svg);
     transform: rotateZ(360deg);
   }
 }
@@ -76,13 +76,12 @@
 }
 
 .loading-mini div {
-  animation-name: loadingCircle;
-  width: 2.5rem;
-  height: 2.5rem;
-  background-image: url(/images/loading.svg);
-  animation-duration: 1.2s;
-  animation-iteration-count: infinite;
-  animation-timing-function: ease;
+  width: 3rem;
+  height: 3rem;
+  background-image: url(/images/loading-spinner.svg);
+  background-size: 2.7rem 2.7rem;
+  background-position: center;
+  background-repeat: no-repeat;
   transform-origin: center;
 }
 

--- a/src/components/NavProvider.js
+++ b/src/components/NavProvider.js
@@ -25,10 +25,10 @@ export default function NavProvider({ children }) {
   }
 
   return (
-    <>
+    <div className="root-container">
       <Header />
       {children}
       <Footer />
-    </>
+    </div>
   );
 }

--- a/src/components/main/MainList.module.css
+++ b/src/components/main/MainList.module.css
@@ -118,21 +118,27 @@ div.divider {
   transition: all 0.3s ease;
 }
 
-@media screen and (max-width: 1279px) {
-  .post-content .post-img-wrap {
-    grid-template-columns: repeat(4, 1fr);
+@media screen and (max-width: 720px) {
+  .post-user-info > a {
+    display: grid;
+    grid-template-areas: "img name" "img id";
+    font-size: var(--h3-font-size);
   }
-}
 
-@media screen and (max-width: 768px) {
-  .post-content .post-img-wrap {
-    grid-template-columns: repeat(3, 1fr);
+  .post-user-info > a img {
+    grid-area: img;
   }
-}
 
-@media screen and (max-width: 480px) {
-  .post-content .post-img-wrap {
-    grid-template-columns: repeat(2, 1fr);
+  .post-user-info > a span:first-child {
+    grid-area: name;
+  }
+
+  .post-user-info > a span:last-child {
+    grid-area: id;
+  }
+
+  .post-user-info time {
+    margin-top: 0;
   }
 }
 

--- a/src/components/modal/PostModal.module.css
+++ b/src/components/modal/PostModal.module.css
@@ -387,18 +387,3 @@ input[type="checkbox"]:checked + label.checkbox::before {
     height: 5rem;
   }
 }
-@media (max-width: 480px) {
-  .post-section {
-    height: 60%;
-  }
-  .post-text {
-    min-width: 30rem;
-    height: 76%;
-  }
-  .profile-info {
-    margin: 0;
-  }
-  .comment-section {
-    height: 35%;
-  }
-}

--- a/src/components/modal/PostModal.module.css
+++ b/src/components/modal/PostModal.module.css
@@ -263,11 +263,10 @@ img.tomong-icon {
 .comment-setting {
   color: var(--black-font-color);
   display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-left: auto;
   gap: 0.8rem;
-
-  position: absolute;
-  bottom: -3rem;
-  right: 3rem;
   font-size: var(--small-text-font-size);
 }
 .comment-setting input {
@@ -275,8 +274,9 @@ img.tomong-icon {
 }
 
 .comment-setting button {
-  position: absolute;
-  bottom: -1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .comment-articles-section {
@@ -327,8 +327,9 @@ img.tomong-icon {
 }
 
 .send-btn {
-  position: relative;
-  top: -1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 input[type="checkbox"]:checked + label.checkbox::before {

--- a/src/components/profile/Profile.module.css
+++ b/src/components/profile/Profile.module.css
@@ -228,6 +228,7 @@
 
 .post-wrap {
   width: 100%;
+  max-width: 24rem;
   aspect-ratio: 1 / 1;
   background-color: var(--background-white);
   border-radius: 1.5rem;


### PR DESCRIPTION
1. 로딩 인디케이터 애셋을 교체했습니다. (향후 디자인 나올 시 새 디자인으로 교체 예정)
2. 커스텀 스크롤 바를 제거하고 네이티브 스크롤 바를 CSS로 커스텀했습니다.
3. 반응형 레이아웃을 위해 레이아웃의 마크업 및 global.css가 변경되었습니다.
4. 메인 피드 리스트에서 표시 사진이 줄어드는 로직을 뷰포트 너비가 아닌 컨테이너 너비를 기준으로 변경했습니다.