### PR TITLE
토몽 관련 반응형 레이아웃 적용

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -287,7 +287,7 @@ body:has(header):has(main):has(footer) main {
     height: 100dvh;
   }
 
-  body {
+  body:not(:has(div#tomong-container)) {
     width: inherit;
     padding-left: 6.4rem;
     padding-right: 6.4rem;

--- a/src/components/tomong/Tomong.jsx
+++ b/src/components/tomong/Tomong.jsx
@@ -43,8 +43,8 @@ export function TomongIntro({ setProcess }) {
         </Button>
       </div>
       <div className={styles["btn-row"]}>
-        <Button onClick={() => history.back()}>이전 페이지로</Button>
-        <Button onClick={() => setProcess(101)}>해몽된 꿈 보러 가기</Button>
+        <Button onClick={() => history.back()}>이전 페이지</Button>
+        <Button onClick={() => setProcess(101)}>해몽된 꿈 목록...</Button>
       </div>
     </>
   );

--- a/src/components/tomong/Tomong.jsx
+++ b/src/components/tomong/Tomong.jsx
@@ -487,8 +487,8 @@ export function TomongRead({ setProcess, tomongDream, before }) {
       </div>
       <div className={styles["btn-row"]}>
         <Button onClick={handleBack}>뒤로</Button>
-        <ButtonLink href={`/${userId}`} highlight={true}>
-          프로필로 이동
+        <ButtonLink href={`/${userId}?post=${tomongDream.id}`} highlight={true}>
+          게시글로 이동
         </ButtonLink>
       </div>
     </>

--- a/src/components/tomong/Tomong.jsx
+++ b/src/components/tomong/Tomong.jsx
@@ -511,7 +511,7 @@ export default function TomongComponent() {
   }
 
   return (
-    <div id="tomong-container" className={styles["container"]}>
+    <>
       <h1>
         <Link href="/">
           <img src="/images/logo-full.svg" alt="DREAMER" width={240} />
@@ -548,6 +548,6 @@ export default function TomongComponent() {
           />
         )}
       </main>
-    </div>
+    </>
   );
 }

--- a/src/components/tomong/Tomong.jsx
+++ b/src/components/tomong/Tomong.jsx
@@ -511,7 +511,7 @@ export default function TomongComponent() {
   }
 
   return (
-    <div className={styles["container"]}>
+    <div id="tomong-container" className={styles["container"]}>
       <h1>
         <Link href="/">
           <img src="/images/logo-full.svg" alt="DREAMER" width={240} />

--- a/src/components/tomong/Tomong.module.css
+++ b/src/components/tomong/Tomong.module.css
@@ -71,7 +71,9 @@
 .btn-row {
   width: 100%;
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
+  gap: 1rem;
 }
 
 .tomong-stamp {
@@ -246,7 +248,9 @@ ul.post-tag li {
   }
 }
 
-/* .container p {
-  position: relative;
-  z-index: 10;
-} */
+@media (max-width: 720px) {
+  .main {
+    width: 90vw;
+    padding: 2rem;
+  }
+}

--- a/src/components/tomong/Tomong.module.css
+++ b/src/components/tomong/Tomong.module.css
@@ -1,23 +1,26 @@
-.container {
-  width: 100vw;
+body:has(.main) {
   height: 100dvh;
   background: var(--background-blue-top);
+  background-color: var(--background-white);
   display: flex;
   flex-direction: column;
   row-gap: 1.6rem;
   justify-content: center;
   align-items: center;
+  overflow-y: hidden;
 }
 
-.container * {
+body:has(.main) * {
   word-break: keep-all;
 }
-.container h1 img {
+
+body:has(.main) h1 img {
   filter: var(--filter-EEF0DE);
 }
+
 .main {
   width: 80vw;
-  height: 80vh;
+  height: 60vh;
   background-color: var(--background-white);
   border-radius: 1.5rem;
   display: grid;
@@ -249,8 +252,33 @@ ul.post-tag li {
 }
 
 @media (max-width: 720px) {
+  body:has(.main) {
+    justify-content: space-around;
+  }
+
+  body:has(.main) h1 img {
+    width: 16rem;
+  }
+
   .main {
     width: 90vw;
+    height: 80%;
     padding: 2rem;
+  }
+
+  .main .tomong-body {
+    row-gap: 0;
+  }
+
+  .main .tomong-body img {
+    width: 50%;
+  }
+
+  .tomong-results-wrapper {
+    padding: 1.6rem;
+  }
+
+  .tomong-results-chevrons {
+    padding: 0 1rem;
   }
 }


### PR DESCRIPTION
1. 토몽 페이지에 모바일 반응형 레이아웃을 적용했습니다.
2. 토몽 UI의 일부 버튼 텍스트를 수정했습니다.
3. 토몽 결과 출력 이후 '프로필로 이동' 버튼을 '게시글로 이동' 버튼으로 수정했습니다. 버튼을 클릭할 시 프로필 페이지의 게시글 모달이 열립니다.