### PR TITLE
회원 정보 페이지에서 Google로 로그인을 인식하지 못하는 문제 수정 외 2건

### DIFF
--- a/src/app/account/page.js
+++ b/src/app/account/page.js
@@ -53,7 +53,7 @@ export default function Account() {
             <dd className={styles["info-value"]}>{userName}</dd>
             <dt className={styles["info-label"]}>계정 유형</dt>
             <dd className={styles["info-value"]}>
-              {via === "google" ? "Google 계정" : "이메일 계정"}
+              {via === "google.com" ? "Google 계정" : "이메일 계정"}
             </dd>
           </dl>
         </section>

--- a/src/components/auth/AuthStateHandler.jsx
+++ b/src/components/auth/AuthStateHandler.jsx
@@ -25,6 +25,7 @@ const authRoutes = {
     "/account",
     "/account/modify-email",
     "/account/modify-password",
+    "/tomong",
   ],
 
   // 인증 체크를 하지 않는 페이지

--- a/src/components/login/SocialLogin.jsx
+++ b/src/components/login/SocialLogin.jsx
@@ -191,7 +191,7 @@ export default function SocialLogin() {
                   src="/images/google-logo.svg"
                   width={40}
                   height={40}
-                  alt="google 로그인"
+                  alt="Google로 로그인"
                 />
               </button>
             </div>


### PR DESCRIPTION
1. 회원 정보 페이지에서 Google로 로그인을 인식하지 못하는 문제를 수정했습니다.
2. 로그인하지 않은 사용자가 /tomong 경로로 접속하지 못하도록 수정했습니다.
3. Google로 로그인 버튼의 대체 텍스트를 'Google로 로그인'으로 수정했습니다.