### PR TITLE
프로필에서 팔로잉 카운트 즉각 반영 외 1건 

### DIFF
--- a/src/app/api/auth/verify/route.js
+++ b/src/app/api/auth/verify/route.js
@@ -37,6 +37,8 @@ export async function GET() {
       via: via,
       uid: uid,
       theme: userDoc.data()?.theme,
+      followingCount: userDoc.data()?.following.length || 0,
+      followersCount: userDoc.data()?.followers.length || 0,
     });
   } catch (error) {
     console.error("Verification error:", error);

--- a/src/components/Controls.jsx
+++ b/src/components/Controls.jsx
@@ -5,10 +5,11 @@ import styles from "./Controls.module.css";
 import Loading from "./Loading";
 import Link from "next/link";
 import { fetchWithAuth } from "@/utils/auth/tokenUtils";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { useRouter } from "next/navigation";
 import { auth } from "@/lib/firebase";
 import { disableScroll, enableScroll } from "@/utils/scrollHandler";
+import { loginSuccess } from "@/store/authSlice";
 
 export const handleClickWithKeyboard = (e) => {
   e.preventDefault();
@@ -695,6 +696,7 @@ export function UsersList({
   const dialogRef = useRef(null);
 
   const { user } = useSelector((state) => state.auth);
+  const dispatch = useDispatch();
   const router = useRouter();
 
   useEffect(() => {
@@ -745,6 +747,16 @@ export function UsersList({
         user.userId === userId ? { ...user, isFollowing: !isFollowing } : user
       )
     );
+
+    dispatch(
+      loginSuccess({
+        user: {
+          ...user,
+          followingCount: user.followingCount + (isFollowing ? -1 : 1),
+        },
+      })
+    );
+
     const res = await fetchWithAuth(`/api/account/follow/${userId}`);
     const data = await res.json();
 
@@ -753,6 +765,14 @@ export function UsersList({
         prevUsers.map((user) =>
           user.userId === userId ? { ...user, isFollowing: !isFollowing } : user
         )
+      );
+      dispatch(
+        loginSuccess({
+          user: {
+            ...user,
+            followingCount: user.followingCount + (isFollowing ? -1 : 1),
+          },
+        })
       );
     }
   };

--- a/src/components/footer/Recommends.jsx
+++ b/src/components/footer/Recommends.jsx
@@ -5,10 +5,15 @@ import Loading from "../Loading";
 import { fetchWithAuth } from "@/utils/auth/tokenUtils";
 import Link from "next/link";
 import { Button } from "../Controls";
+import { useDispatch, useSelector } from "react-redux";
+import { loginSuccess } from "@/store/authSlice";
 
 export default function Recommends({ className, styles }) {
   const [usersList, setUsersList] = useState([]);
   const [loading, setLoading] = useState(true);
+
+  const dispatch = useDispatch();
+  const user = useSelector((state) => state.auth.user);
 
   useEffect(() => {
     const fetchUsers = async () => {
@@ -22,10 +27,12 @@ export default function Recommends({ className, styles }) {
     fetchUsers();
   }, []);
 
-  const handleFollow = async (user) => {
+  const handleFollow = async (targetUser) => {
+    const isFollowingBool = targetUser.isFollowing;
+
     setUsersList((prev) =>
       prev.map((u) => {
-        if (u.userId === user.userId) {
+        if (u.userId === targetUser.userId) {
           return {
             ...u,
             isFollowing: !u.isFollowing,
@@ -35,18 +42,42 @@ export default function Recommends({ className, styles }) {
       })
     );
 
-    const response = await fetchWithAuth(`/api/account/follow/${user.userId}`);
+    dispatch(
+      loginSuccess({
+        user: {
+          ...user,
+          followingCount: isFollowingBool
+            ? user.followingCount - 1
+            : user.followingCount + 1,
+        },
+      })
+    );
+
+    const response = await fetchWithAuth(
+      `/api/account/follow/${targetUser.userId}`
+    );
 
     if (!response.ok) {
       setUsersList((prev) =>
         prev.map((u) => {
-          if (u.userId === user.userId) {
+          if (u.userId === targetUser.userId) {
             return {
               ...u,
               isFollowing: !u.isFollowing,
             };
           }
           return u;
+        })
+      );
+
+      dispatch(
+        loginSuccess({
+          user: {
+            ...user,
+            followingCount: isFollowingBool
+              ? user.followingCount - 1
+              : user.followingCount + 1,
+          },
         })
       );
     }

--- a/src/components/profile/ProfileInfo.jsx
+++ b/src/components/profile/ProfileInfo.jsx
@@ -2,6 +2,7 @@ import { UsersList } from "../Controls";
 import { useState, useEffect, useRef } from "react";
 import { fetchWithAuth } from "@/utils/auth/tokenUtils";
 import { handleClickWithKeyboard } from "../Controls";
+import { useSelector } from "react-redux";
 
 export default function ProfileInfo({
   profile,
@@ -17,6 +18,8 @@ export default function ProfileInfo({
   const [isUsersLoading, setIsUsersLoading] = useState(true);
 
   const statListRef = useRef(null);
+
+  const user = useSelector((state) => state.auth.user);
 
   // 팔로워, 팔로잉 목록이 한 줄에 표시되도록 레이아웃 조정
   useEffect(() => {
@@ -136,7 +139,13 @@ export default function ProfileInfo({
               tabIndex={0}
               onKeyDown={handleClickWithKeyboard}
             >
-              팔로잉 {profile.followingCount ? profile.followingCount : 0}명
+              팔로잉{" "}
+              {profile.isMyself
+                ? user.followingCount
+                : profile.followingCount
+                  ? profile.followingCount
+                  : 0}
+              명
             </li>
             <li
               onClick={handleFollowersClick}
@@ -144,7 +153,13 @@ export default function ProfileInfo({
               tabIndex={0}
               onKeyDown={handleClickWithKeyboard}
             >
-              팔로워 {profile.followersCount ? profile.followersCount : 0}명
+              팔로워{" "}
+              {profile.isMyself
+                ? user.followersCount
+                : profile.followersCount
+                  ? profile.followersCount
+                  : 0}
+              명
             </li>
           </ul>
           <p className={styles["profile-bio"]}>{profile.bio}</p>

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -23,6 +23,7 @@ export const store = configureStore({
     getDefaultMiddleware({
       serializableCheck: false,
     }),
+  devTools: process.env.NEXT_PUBLIC_BASE_URL.startsWith("http://"),
 });
 
 export const persistor = persistStore(store);

--- a/src/utils/auth/checkUser.js
+++ b/src/utils/auth/checkUser.js
@@ -20,6 +20,8 @@ export const checkUserExists = async (dispatch) => {
             userName: userData.userName,
             profileImageUrl: userData.profileImageUrl,
             theme: userData.theme,
+            followersCount: userData.followersCount,
+            followingCount: userData.followingCount,
           },
         })
       );


### PR DESCRIPTION
1. 자기 자신의 프로필 페이지에서 팔로우를 눌렀을 경우 데이터가 즉각 반영되도록 하기 위해 Redux로 팔로잉 및 팔로워 수를 관리하게끔 수정했습니다.
2. 배포 환경에서 Redux DevTools를 비활성화했습니다.