### PR TITLE
피드 알고리즘 개선 외 2건

### DIFF
--- a/src/app/api/post/feeds/route.js
+++ b/src/app/api/post/feeds/route.js
@@ -144,9 +144,9 @@ export async function GET(request) {
         };
 
         // 점수 계산 및 게시물 데이터 가공
-        const posts = allDocs
-          .map((doc) => {
-            const postData = doc.data();
+        const posts = await Promise.all(
+          allDocs.map(async (document) => {
+            const postData = document.data();
 
             const commentsLength = postData.comments
               ? postData.comments.filter((comment) => !comment.isDeleted).length
@@ -173,14 +173,27 @@ export async function GET(request) {
               commentsLength
             );
 
+            // 신고 점수 계산 (수정된 부분)
+            const reportRef = doc(db, "reports", document.id);
+            const reportSnap = await getDoc(reportRef);
+            let reportPenalty = 0;
+            if (reportSnap.exists()) {
+              const reportData = reportSnap.data();
+              if (reportData.reportCount >= 2) {
+                const reportCount = reportData.reportCount; // reportCount 변수 추가
+                reportPenalty = reportCount * 40; // 신고 횟수 * 40점 감점
+              }
+            }
+
             const totalScore =
               followScore +
               interactionScore +
               genreMatchScore +
-              timeFreshnessScore;
+              timeFreshnessScore -
+              reportPenalty;
 
             return {
-              id: doc.id,
+              id: document.id,
               title: postData.title,
               content: postData.content,
               authorUid: postData.authorUid,
@@ -207,7 +220,9 @@ export async function GET(request) {
               isPrivate: postData.isPrivate || false,
             };
           })
-          .sort((a, b) => b.score - a.score);
+        );
+
+        posts.sort((a, b) => b.score - a.score);
 
         const lastVisible = allDocs[allDocs.length - 1];
 
@@ -311,9 +326,9 @@ export async function GET(request) {
       };
 
       // 점수 계산 및 게시물 데이터 가공
-      const posts = allDocs
-        .map((doc) => {
-          const postData = doc.data();
+      const posts = await Promise.all(
+        allDocs.map(async (document) => {
+          const postData = document.data();
 
           const commentsLength = postData.comments
             ? postData.comments.filter((comment) => !comment.isDeleted).length
@@ -340,15 +355,28 @@ export async function GET(request) {
             commentsLength
           );
 
+          // 신고 점수 계산 (수정된 부분)
+          const reportRef = doc(db, "reports", document.id);
+          const reportSnap = await getDoc(reportRef);
+          let reportPenalty = 0;
+          if (reportSnap.exists()) {
+            const reportData = reportSnap.data();
+            if (reportData.reportCount >= 2) {
+              const reportCount = reportData.reportCount; // reportCount 변수 추가
+              reportPenalty = reportCount * 40; // 신고 횟수 * 20점 감점
+            }
+          }
+
           const totalScore =
             followScore +
             interactionScore +
             genreMatchScore +
-            timeFreshnessScore;
+            timeFreshnessScore -
+            reportPenalty;
 
           return {
-            id: doc.id,
-            objectID: doc.id,
+            id: document.id,
+            objectID: document.id,
             title: postData.title,
             content: postData.content,
             authorUid: postData.authorUid,
@@ -375,7 +403,9 @@ export async function GET(request) {
             isPrivate: postData.isPrivate || false,
           };
         })
-        .sort((a, b) => b.score - a.score);
+      );
+
+      posts.sort((a, b) => b.score - a.score);
 
       const lastVisible = allDocs[allDocs.length - 1];
 

--- a/src/components/main/MainList.jsx
+++ b/src/components/main/MainList.jsx
@@ -16,7 +16,7 @@ export default function MainList() {
   const [isShowModal, setIsShowModal] = useState(false);
   const [selectedPostId, setSelectedPostId] = useState(null);
   const mainRef = useRef(null);
-  const LIMIT = 5;
+  const LIMIT = 10;
 
   const fetchPosts = async (nextCursor = null) => {
     if (isLoading) return;

--- a/src/components/report/Report.jsx
+++ b/src/components/report/Report.jsx
@@ -33,12 +33,15 @@ export default function ReportModal({ isOpen, closeModal, postId }) {
       }
 
       setIsLoading(false);
-      enableScroll();
+
       alert("신고가 접수되었습니다.");
       closeModal();
     } catch (error) {
       alert(error.message);
       closeModal();
+    } finally {
+      closeModal();
+      enableScroll();
     }
   };
 


### PR DESCRIPTION
1. 피드 알고리즘에 신고 점수를 포함하여 신고 횟수가 2개 이상일 경우 점수를 신고 횟수 * 40점을 깎습니다.
2. 메인 피드 게시글 로드를 5개씩에서 10개씩으로 제한을 늘렸습니다.
3. 이미 신고된 글을 재신고했을 경우 모달이 닫히면서 스크롤이 작동하지 않는 문제를 수정했습니다.