### PR TITLE
iOS Safari에서 의도하지 않게 모달이 표시되는 문제 수정

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -9,15 +9,19 @@ import ThemeHandler from "@/components/theme/ThemeHandler";
 
 export const metadata = metadataMaker();
 
+export const viewport = {
+  width: "device-width",
+  initialScale: 1.0,
+  maximumScale: 1.0,
+  userScalable: "no",
+  viewportFit: "cover",
+};
+
 export default function RootLayout({ children }) {
   return (
     <html lang="ko" suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={themeScript()} />
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"
-        />
       </head>
       <body>
         <ThemeHandler>

--- a/src/components/modal/PostModal.module.css
+++ b/src/components/modal/PostModal.module.css
@@ -25,6 +25,8 @@
   display: flex;
   padding: 3.7rem 0 3.5rem 3.2rem;
   box-shadow: 0 0 15px 0 rgba(0, 0, 0, 0.2);
+  -webkit-overflow-scrolling: touch; /*  iOS 스크롤 동작 개선 */
+  overscroll-behavior: contain; /* 스크롤 전파 방지 */
 }
 
 .post-section {
@@ -437,5 +439,11 @@ input[type="checkbox"]:checked + label.checkbox::before {
   }
   .dream-score {
     font-size: var(--tiny-text-font-size);
+  }
+}
+
+@supports (-webkit-touch-callout: none) {
+  .post-modal {
+    height: 75dvh;
   }
 }


### PR DESCRIPTION
1. 뷰포트 메타 태그를 객체로 정의하여 더 의도적으로 뷰포트 메타 태그가 작동하게끔 수정했습니다.
2. iOS Safari에서 하단 주소 창이 게시글 모달을 가리는 문제가 수정되었습니다.